### PR TITLE
Possible unintended reference comparison

### DIFF
--- a/src/CppAst.CodeGen/CSharp/CSharpConverter.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpConverter.cs
@@ -621,7 +621,7 @@ namespace CppAst.CodeGen.CSharp
 
         public ICSharpContainer GetCSharpContainer(CppElement element, CSharpElement context)
         {
-            if (!ReferenceEquals(element.Parent, CurrentCppCompilation) && !ReferenceEquals(element.Parent, CurrentCppCompilation.System))
+            if ((CppCompilation)element.Parent != CurrentCppCompilation && (CppGlobalDeclarationContainer)element.Parent != CurrentCppCompilation.System)
             {
                 // Default implementation, returns the current context
                 var nextContext = context;

--- a/src/CppAst.CodeGen/CSharp/CSharpConverter.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpConverter.cs
@@ -621,7 +621,7 @@ namespace CppAst.CodeGen.CSharp
 
         public ICSharpContainer GetCSharpContainer(CppElement element, CSharpElement context)
         {
-            if ((CppCompilation)element.Parent != CurrentCppCompilation && (CppGlobalDeclarationContainer)element.Parent != CurrentCppCompilation.System)
+            if (!ReferenceEquals(element.Parent, CurrentCppCompilation) && !ReferenceEquals(element.Parent, CurrentCppCompilation.System))
             {
                 // Default implementation, returns the current context
                 var nextContext = context;

--- a/src/CppAst.CodeGen/CSharp/CSharpConverter.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpConverter.cs
@@ -621,7 +621,7 @@ namespace CppAst.CodeGen.CSharp
 
         public ICSharpContainer GetCSharpContainer(CppElement element, CSharpElement context)
         {
-            if (element.Parent != CurrentCppCompilation && element.Parent != CurrentCppCompilation.System)
+            if (!ReferenceEquals(element.Parent, CurrentCppCompilation) && !ReferenceEquals(element.Parent, CurrentCppCompilation.System))
             {
                 // Default implementation, returns the current context
                 var nextContext = context;


### PR DESCRIPTION
We're comparing a concrete type against an interface type, and may want to explicitly state we're comparing the reference equality or cast the `element.Parent` to the correct concrete type.