### PR TITLE
Added ICSharpMember to more classes.

### DIFF
--- a/src/CppAst.CodeGen/CSharp/CSharpEnumItem.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpEnumItem.cs
@@ -8,7 +8,7 @@ using CppAst.CodeGen.Common;
 
 namespace CppAst.CodeGen.CSharp
 {
-    public class CSharpEnumItem : CSharpElement, ICSharpWithComment, ICSharpAttributesProvider
+    public class CSharpEnumItem : CSharpElement, ICSharpWithComment, ICSharpAttributesProvider, ICSharpMember
     {
         public CSharpEnumItem(string name, string value = null)
         {

--- a/src/CppAst.CodeGen/CSharp/CSharpMethod.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpMethod.cs
@@ -9,7 +9,7 @@ using CppAst.CodeGen.Common;
 
 namespace CppAst.CodeGen.CSharp
 {
-    public class CSharpMethod : CSharpElement, ICSharpAttributesProvider, ICSharpElementWithVisibility
+    public class CSharpMethod : CSharpElement, ICSharpAttributesProvider, ICSharpElementWithVisibility, ICSharpMember
     {
         public CSharpMethod()
         {

--- a/src/CppAst.CodeGen/CSharp/CSharpNamespace.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpNamespace.cs
@@ -7,7 +7,7 @@ using CppAst.CodeGen.Common;
 
 namespace CppAst.CodeGen.CSharp
 {
-    public class CSharpNamespace : CSharpElement, ICSharpContainer
+    public class CSharpNamespace : CSharpElement, ICSharpContainer, ICSharpMember
     {
         public CSharpNamespace(string name)
         {

--- a/src/CppAst.CodeGen/CSharp/CSharpProperty.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpProperty.cs
@@ -8,7 +8,7 @@ using CppAst.CodeGen.Common;
 
 namespace CppAst.CodeGen.CSharp
 {
-    public class CSharpProperty : CSharpElement, ICSharpWithComment, ICSharpAttributesProvider, ICSharpElementWithVisibility
+    public class CSharpProperty : CSharpElement, ICSharpWithComment, ICSharpAttributesProvider, ICSharpElementWithVisibility, ICSharpMember
     {
         public CSharpProperty(string name)
         {


### PR DESCRIPTION
Very basic PR, just adds ICSharpMember interface onto 4 classes that had fully public Name properties, but were missing it: `CSharpProperty`, `CSharpNamespace`, `CSharpMethod` and `CSharpEnumItem`.
Classes like `CSharpXmlAttribute` and `CSharpParamComment` also have such properties, but I assume those don't fit.