### PR TITLE
Making CppElement and Parent public sets, in order to be able to set the from non-internal publics

### DIFF
--- a/src/CppAst.CodeGen/CSharp/CSharpElement.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpElement.cs
@@ -9,9 +9,9 @@ namespace CppAst.CodeGen.CSharp
 {
     public abstract class CSharpElement : ICSharpElement
     {
-        public CppElement CppElement { get; internal set; }
+        public CppElement CppElement { get; set; }
 
-        public CSharpElement Parent { get; internal set; }
+        public CSharpElement Parent { get; set; }
 
         public abstract void DumpTo(CodeWriter writer);
 


### PR DESCRIPTION
Providing public access to `CppElement` and `Parent` so they can be set from non-internal plugins. This resolves #24 
