### PR TITLE
Map macros of macros

### DIFF
--- a/src/CppAst.CodeGen.Tests/ConverterTests.cs
+++ b/src/CppAst.CodeGen.Tests/ConverterTests.cs
@@ -68,7 +68,8 @@ struct {
 #endif
 #define MYNAME_X 1
 #define MYNAME_Y 2
-#define MYNAME_XYWZ 3
+#define MYNAME_XYWZ MYNAME_X
+#define MYNAME_XY (MYNAME_X|MYNAME_Y)
 
 EXPORT_API void function0(int x);
             ", options);


### PR DESCRIPTION
This PR is to add support for macros like `#define MY_MACRO_3 (MY_MACRO_1 + MY_MACRO_2)`

Previously, they would be mapped into a blank expression. eg `const int MY_MACRO_3 = ( );`