### PR TITLE
Support Doxygen brief, remark, remarks, return, sa, and since

### DIFF
--- a/src/CppAst.CodeGen/CSharp/CSharpParamComment.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpParamComment.cs
@@ -7,21 +7,19 @@ using CppAst.CodeGen.Common;
 
 namespace CppAst.CodeGen.CSharp
 {
-    public class CSharpParamComment : CSharpComment
+    public class CSharpParamComment : CSharpXmlComment
     {
-        public CSharpParamComment(string name)
+        public CSharpParamComment(string name) : base("param")
         {
-            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Attributes.Add(new CSharpXmlAttribute("name", name ?? throw new ArgumentNullException(nameof(name))));
+            IsInline = true;
         }
-
-        public string Name { get; set; }
 
         /// <inheritdoc />
         public override void DumpTo(CodeWriter writer)
         {
-            writer.Write("<param name=\"").Write(Name).Write("\">");
-            DumpChildrenTo(writer);
-            writer.WriteLine("</param>");
+            base.DumpTo(writer);
+            writer.WriteLine();
         }
     }
 }

--- a/src/CppAst.CodeGen/CSharp/Comments/CSharpReturnComment.cs
+++ b/src/CppAst.CodeGen/CSharp/Comments/CSharpReturnComment.cs
@@ -6,13 +6,17 @@ using CppAst.CodeGen.Common;
 
 namespace CppAst.CodeGen.CSharp
 {
-    public class CSharpReturnComment : CSharpComment
+    public class CSharpReturnComment : CSharpXmlComment
     {
+        public CSharpReturnComment() : base("returns")
+        {
+            IsInline = true;
+        }
+
         public override void DumpTo(CodeWriter writer)
         {
-            writer.Write("<returns>");
-            DumpChildrenTo(writer);
-            writer.WriteLine("</returns>");
+            base.DumpTo(writer);
+            writer.WriteLine();
         }
     }
 }

--- a/src/CppAst.CodeGen/CSharp/Comments/CSharpSeeAlsoComment.cs
+++ b/src/CppAst.CodeGen/CSharp/Comments/CSharpSeeAlsoComment.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace CppAst.CodeGen.CSharp
+{
+    public class CSharpSeeAlsoComment : CSharpXmlComment
+    {
+        public CSharpSeeAlsoComment(CppComment cppComment) : base("seealso")
+        {
+            var builder = new StringBuilder();
+            var cppCommentChildren = new Stack<CppComment>(cppComment.Children);
+
+            while (cppCommentChildren.Count > 0)
+            {
+                var child = cppCommentChildren.Pop();
+
+                if (child.Children != null && child.Children.Count > 0)
+                {
+                    foreach (var c in child.Children)
+                    {
+                        cppCommentChildren.Push(c);
+                    }
+                }
+                else
+                {
+                    switch (child)
+                    {
+                        case CppCommentCommand command:
+                        {
+                            switch (command.CommandName)
+                            {
+                                case "ref":
+                                    builder.Append(string.Join(" ", command.Arguments));
+                                    break;
+                                default:
+                                    builder.Append(child);
+                                    break;
+                            }
+
+                            break;
+                        }
+                        default:
+                            builder.Append(child);
+                            break;
+                    }
+                }
+            }
+
+            IsSelfClosing = true;
+            Attributes.Add(new CSharpXmlAttribute("cref", builder.ToString()));
+        }
+    }
+}

--- a/src/CppAst.CodeGen/CSharp/Comments/CSharpSinceComment.cs
+++ b/src/CppAst.CodeGen/CSharp/Comments/CSharpSinceComment.cs
@@ -1,0 +1,18 @@
+﻿using CppAst.CodeGen.Common;
+
+namespace CppAst.CodeGen.CSharp
+{
+    public class CSharpSinceComment : CSharpXmlComment
+    {
+        public CSharpSinceComment() : base("since")
+        {
+            IsInline = true;
+        }
+
+        public override void DumpTo(CodeWriter writer)
+        {
+            base.DumpTo(writer);
+            writer.WriteLine();
+        }
+    }
+}

--- a/src/CppAst.CodeGen/CSharp/Plugins/DefaultCommentConverter.cs
+++ b/src/CppAst.CodeGen/CSharp/Plugins/DefaultCommentConverter.cs
@@ -2,6 +2,8 @@
 // Licensed under the BSD-Clause 2 license.
 // See license.txt file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace CppAst.CodeGen.CSharp
@@ -22,6 +24,7 @@ namespace CppAst.CodeGen.CSharp
             }
 
             var comment = cppDecl.Comment;
+
             if (comment?.Children == null)
             {
                 return null;
@@ -29,18 +32,14 @@ namespace CppAst.CodeGen.CSharp
 
             var csFullComment = new CSharpFullComment();
 
+            CSharpXmlComment csSummary = null;
             CSharpXmlComment csRemarks = null;
+
+            var uncategorized = new List<CppComment>();
 
             for (var i = 0; i < comment.Children.Count; i++)
             {
                 var childComment = comment.Children[i];
-                if (i == 0)
-                {
-                    var summary = new CSharpXmlComment("summary");
-                    summary.Children.Add(GetAsCSharpComment(childComment));
-                    csFullComment.Children.Add(summary);
-                    continue;
-                }
 
                 switch (childComment.Kind)
                 {
@@ -54,35 +53,101 @@ namespace CppAst.CodeGen.CSharp
 
                     case CppCommentKind.BlockCommand:
                         var blockCommand = (CppCommentBlockCommand)childComment;
-                        if (blockCommand.CommandName == "return")
+
+                        switch (blockCommand.CommandName)
                         {
-                            var returnComment = new CSharpReturnComment();
-                            returnComment.Children.Add(GetChildAsCSharpComment(blockCommand));
-                            csFullComment.Children.Add(returnComment);
+                            case "return":
+                            case "returns":
+                                var returnComment = new CSharpReturnComment();
+                                returnComment.Children.Add(GetChildAsCSharpComment(childComment));
+                                csFullComment.Children.Add(returnComment);
+                                break;
+                            case "see":
+                            case "sa":
+                                if (childComment.Children != null && childComment.Children.Count > 0)
+                                {
+                                    var seealso = new CSharpSeeAlsoComment(childComment);
+                                    csFullComment.Children.Add(seealso);
+                                }
+                                break;
+
+                            case "brief":
+                                csSummary ??= new CSharpXmlComment("summary");
+                                csSummary.Children.Add(GetChildAsCSharpComment(childComment));
+                                break;
+                            case "remark":
+                            case "remarks":
+                                csRemarks ??= new CSharpXmlComment("remarks");
+                                csRemarks.Children.Add(GetChildAsCSharpComment(childComment));
+                                break;
+                            case "since":
+                                var since = new CSharpSinceComment();
+                                since.Children.Add(GetChildAsCSharpComment(childComment));
+                                csFullComment.Children.Add(since);
+                                break;
+                            default:
+                                var genericComment = new CSharpXmlComment(blockCommand.CommandName);
+                                genericComment.Children.Add(GetChildAsCSharpComment(childComment));
+                                csFullComment.Children.Add(genericComment);
+                                break;
                         }
-                        else if (blockCommand.CommandName == "see")
-                        {
-                            var seealso = new CSharpXmlComment("seealso") { IsSelfClosing = true };
-                            seealso.Attributes.Add(new CSharpXmlAttribute("cref", GetChildAsText(childComment)));
-                            csFullComment.Children.Add(seealso);
-                        }
-                        else
-                        {
-                            if (csRemarks == null) csRemarks = new CSharpXmlComment("remarks");
-                            AddComment(csRemarks, childComment);
-                        }
+
                         break;
                     default:
-                        if (csRemarks == null) csRemarks = new CSharpXmlComment("remarks");
-                        AddComment(csRemarks, childComment);
+                        uncategorized.Add(childComment);
                         break;
                 }
+            }
+
+            foreach (var uncategorizedComment in uncategorized)
+            {
+                if (csSummary == null)
+                {
+                    csSummary = new CSharpXmlComment("summary");
+                    AddComment(csSummary, uncategorizedComment);
+                }
+                else
+                {
+                    csRemarks ??= new CSharpXmlComment("remarks");
+                    AddComment(csRemarks, uncategorizedComment);
+                }
+            }
+
+            if (csSummary != null && csSummary.Children.Count > 0)
+            {
+                csFullComment.Children.Add(csSummary);
             }
 
             if (csRemarks != null && csRemarks.Children.Count > 0)
             {
                 csFullComment.Children.Add(csRemarks);
             }
+
+            var tagOrdinals = new[]
+            {
+                "summary", "typeparam", "param",
+                "returns", "exception", "remarks",
+                "seealso", "example", "since",
+            };
+
+            csFullComment.Children.Sort((first, second) =>
+            {
+                var firstXml = first as CSharpXmlComment;
+                var secondXml = second as CSharpXmlComment;
+
+                if (firstXml == null && secondXml == null) return 0;
+                if (firstXml == null) return -1;
+                if (secondXml == null) return 1;
+
+                var firstOrdinal = Array.IndexOf(tagOrdinals, firstXml.TagName);
+                var secondOrdinal = Array.IndexOf(tagOrdinals, secondXml.TagName);
+
+                firstOrdinal = firstOrdinal != -1 ? firstOrdinal : tagOrdinals.Length;
+                secondOrdinal = secondOrdinal != -1 ? secondOrdinal : tagOrdinals.Length;
+
+                return firstOrdinal - secondOrdinal;
+            });
+
 
             return csFullComment;
         }
@@ -109,6 +174,7 @@ namespace CppAst.CodeGen.CSharp
         private static void AddComment(CSharpComment dest, CppComment comment)
         {
             var text = GetAsText(comment);
+
             if (!string.IsNullOrEmpty(text))
             {
                 dest.Children.Add(new CSharpTextComment(text));
@@ -119,6 +185,7 @@ namespace CppAst.CodeGen.CSharp
         {
             if (comment?.Children == null) return null;
             var builder = new StringBuilder();
+
             foreach (var child in comment.Children)
             {
                 builder.Append(child);


### PR DESCRIPTION
I've tried to add some better Doxygen support. Specifically, This uses "brief" for the summary if it exists in the Doxygen comment, otherwise it will default to the first uncategorized comment.

This also adds some aliases for existing tags, and will map command comments to a generic C# xml tag. Lastly, I've applied sorting to many of the known C# tags. This is opinionated, but, I tried to use something that seemed to be standard for C#.