### PR TITLE
Ignore typedefs of opaque structs and void

### DIFF
--- a/src/CppAst.CodeGen/CSharp/CSharpStruct.cs
+++ b/src/CppAst.CodeGen/CSharp/CSharpStruct.cs
@@ -14,6 +14,19 @@ namespace CppAst.CodeGen.CSharp
         /// <inheritdoc />
         protected override string DeclarationKind => "struct";
 
-        public bool IsOpaque => CppElement is CppClass cppClass && !cppClass.IsDefinition;
+        public bool IsOpaque
+        {
+            get
+            {
+                var cppElement = CppElement;
+
+                while (cppElement is CppTypedef cppTypedef)
+                {
+                    cppElement = cppTypedef.ElementType;
+                }
+
+                return cppElement is CppClass cppClass && !cppClass.IsDefinition;
+            }
+        }
     }
 }


### PR DESCRIPTION
- Made the check for whether a struct is opaque recursive to handle typedefs of typedefs.
- Added logic to ignore creating a typedef wrapper if the typedef element type is "void" which is invalid c#. 
- Ignore typedefs to opaque structs. 

Fixes #28 